### PR TITLE
fix: correccion tests census

### DIFF
--- a/decide/census/tests.py
+++ b/decide/census/tests.py
@@ -37,42 +37,42 @@ class CensusTestCase(BaseTestCase):
         self.assertEqual(response.json(), 'Valid voter')
 
     def test_list_voting(self):
-        response = self.client.get('/census/?voting_id={}'.format(1), format='json')
+        response = self.client.get('/census/createCensus/?voting_id={}'.format(1), format='json')
         self.assertEqual(response.status_code, 401)
 
         self.login(user='noadmin')
-        response = self.client.get('/census/?voting_id={}'.format(1), format='json')
+        response = self.client.get('/census/createCensus/?voting_id={}'.format(1), format='json')
         self.assertEqual(response.status_code, 403)
 
         self.login()
-        response = self.client.get('/census/?voting_id={}'.format(1), format='json')
+        response = self.client.get('/census/createCensus/?voting_id={}'.format(1), format='json')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'voters': [1]})
 
     def test_add_new_voters_conflict(self):
         data = {'voting_id': 1, 'voters': [1]}
-        response = self.client.post('/census/', data, format='json')
+        response = self.client.post('/census/createCensus/', data, format='json')
         self.assertEqual(response.status_code, 401)
 
         self.login(user='noadmin')
-        response = self.client.post('/census/', data, format='json')
+        response = self.client.post('/census/createCensus/', data, format='json')
         self.assertEqual(response.status_code, 403)
 
         self.login()
-        response = self.client.post('/census/', data, format='json')
+        response = self.client.post('/census/createCensus/', data, format='json')
         self.assertEqual(response.status_code, 409)
 
     def test_add_new_voters(self):
         data = {'voting_id': 2, 'voters': [1,2,3,4]}
-        response = self.client.post('/census/', data, format='json')
+        response = self.client.post('/census/createCensus/', data, format='json')
         self.assertEqual(response.status_code, 401)
 
         self.login(user='noadmin')
-        response = self.client.post('/census/', data, format='json')
+        response = self.client.post('/census/createCensus/', data, format='json')
         self.assertEqual(response.status_code, 403)
 
         self.login()
-        response = self.client.post('/census/', data, format='json')
+        response = self.client.post('/census/createCensus/', data, format='json')
         self.assertEqual(response.status_code, 201)
         self.assertEqual(len(data.get('voters')), Census.objects.count() - 1)
 
@@ -82,7 +82,7 @@ class CensusTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(0, Census.objects.count())
 
-class CensusExportation:
+class CensusExportationXML:
     def test_positive_export_to_xml(self):
         response = self.client.get('/census/export-to-xml/', format='json')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Al cambiar una de las urls de census,
3 tests habian dejado de funcionar.
Ya han sido arreglados.